### PR TITLE
Fix for allowed image extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Update logic to use MIME types to decide whether image or document endpoint to be used
 
 ## [0.1.1] - 2022-08-31
 ### Fixed

--- a/src/API.ts
+++ b/src/API.ts
@@ -5,16 +5,16 @@ import FileMetadata from "./FileMetadata";
 import GlobalConfiguration from "./GlobalConfiguration";
 import OmnichannelChatToken from "./OmnichannelChatToken";
 
-enum Operation {
+enum AmsApiOperation {
     Create = "Create",
     Upload = "Upload"
 }
 
 enum DocumentTypes {
-    CreateDocument = 'sharing/file',
-    UploadDocument = 'original',
-    CreateImage = 'pish/image',
-    UploadImage = 'imgpsh'
+    CreateDocumentType = 'sharing/file',
+    UploadDocumentType = 'original',
+    CreateImageType = 'pish/image',
+    UploadImageType = 'imgpsh'
 }
 
 enum HeadersName {
@@ -95,19 +95,19 @@ const skypeTokenAuth = async (chatToken: OmnichannelChatToken): Promise<Response
 }
 
 
-const getTypeFromFile = (type: string, name: string, operation: string) => {
+const defineTypeForOperation = (fileType: string, fileName: string, apiOperation: string) => {
 
-    if (type.includes('image')) {
-        const stripFileName = name.split('.');
+    if (fileType.includes('image')) {
+        const stripFileName = fileName.split('.');
         if (stripFileName.length > 1) {
             if (amsValidImageTypes.includes(stripFileName[1])) {
-                return operation === Operation.Create ? DocumentTypes.CreateImage : DocumentTypes.UploadImage;
+                return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateImageType : DocumentTypes.UploadImageType;
             } else {
-                return operation === Operation.Create ? DocumentTypes.CreateDocument : DocumentTypes.UploadDocument;
+                return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;
             }
         }
     }
-    return operation === Operation.Create ? DocumentTypes.CreateDocument : DocumentTypes.UploadDocument;
+    return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;
 }
 
 const createObject = async (id: string, file: File, chatToken: OmnichannelChatToken): Promise<AMSCreateObjectResponse> => {
@@ -116,7 +116,7 @@ const createObject = async (id: string, file: File, chatToken: OmnichannelChatTo
     const permissions = {
         [id]: ['read']
     };
-    const typeObject = getTypeFromFile(file.type, file.name, Operation.Create);
+    const typeObject = defineTypeForOperation(file.type, file.name, AmsApiOperation.Create);
     const body = {
         filename: file.name,
         permissions,
@@ -152,7 +152,7 @@ const uploadDocument = async (documentId: string, file: File | AMSFileInfo, chat
 
     patchChatToken(chatToken);
 
-    const typeObject = getTypeFromFile(file.type, file.name, Operation.Upload);
+    const typeObject = defineTypeForOperation(file.type, file.name, AmsApiOperation.Upload);
     const url = `${chatToken.amsEndpoint || chatToken?.regionGTMS?.ams}/v1/objects/${documentId}/content/${typeObject}`;
     const headers = {
         ...createDefaultHeaders(chatToken.token),

--- a/src/API.ts
+++ b/src/API.ts
@@ -109,9 +109,9 @@ const defineTypeForOperation = (fileType: string, fileName: string, apiOperation
         if (stripFileName) {
             if (amsValidImageTypes.includes(stripFileName)) {
                 return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateImageType : DocumentTypes.UploadImageType;
-            } else {
-                return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;
             }
+            return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;
+
         }
     }
     return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;

--- a/src/API.ts
+++ b/src/API.ts
@@ -47,7 +47,7 @@ interface AMSHeaders {
     [HeadersName.AcceptEncoding]?: string;
 }
 
-const validImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'heic', 'heif', 'webp'];
+const amsValidImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'heic', 'heif', 'webp'];
 
 const patchChatToken = (chatToken: OmnichannelChatToken) => {
     // Temporary
@@ -100,7 +100,7 @@ const getTypeFromFile = (type: string, name: string, operation: string) => {
     if (type.includes('image')) {
         const stripFileName = name.split('.');
         if (stripFileName.length > 1) {
-            if (validImageTypes.includes(stripFileName[1])) {
+            if (amsValidImageTypes.includes(stripFileName[1])) {
                 return operation === Operation.Create ? DocumentTypes.CreateImage : DocumentTypes.UploadImage;
             } else {
                 return operation === Operation.Create ? DocumentTypes.CreateDocument : DocumentTypes.UploadDocument;
@@ -186,7 +186,7 @@ const getViewStatus = async (fileMetadata: FileMetadata, chatToken: OmnichannelC
 
     patchChatToken(chatToken);
 
-    const url = `${chatToken.amsEndpoint || chatToken?.regionGTMS?.ams}/v1/objects/${fileMetadata.id}/views/${validImageTypes.includes(fileMetadata.type) ? 'imgpsh_fullsize_anim' : 'original'}/status`;
+    const url = `${chatToken.amsEndpoint || chatToken?.regionGTMS?.ams}/v1/objects/${fileMetadata.id}/views/${amsValidImageTypes.includes(fileMetadata.type) ? 'imgpsh_fullsize_anim' : 'original'}/status`;
 
     const headers = createDefaultHeaders(chatToken.token);
 
@@ -229,7 +229,7 @@ const getView = async (fileMetadata: FileMetadata, viewLocation: string, chatTok
 
     const headers = createDefaultHeaders(chatToken.token);
 
-    if (validImageTypes.includes(fileMetadata.type)) {
+    if (amsValidImageTypes.includes(fileMetadata.type)) {
         headers[HeadersName.Accept] = 'image/webp,image/ *,*/*;q=0.8';
         headers[HeadersName.AcceptEncoding] = 'gzip, deflate, sdch, br';
     }

--- a/src/API.ts
+++ b/src/API.ts
@@ -94,13 +94,20 @@ const skypeTokenAuth = async (chatToken: OmnichannelChatToken): Promise<Response
     }
 }
 
+const extractExtensionFromFileName = (fileName : string) : string => {
+    if (fileName){
+        //this return the pure extension , or the whole name in case of not '.' in the string
+        return fileName.substring(fileName.lastIndexOf('.')+1);
+    }
+    return fileName;
+}
 
 const defineTypeForOperation = (fileType: string, fileName: string, apiOperation: string) => {
 
     if (fileType.includes('image')) {
-        const stripFileName = fileName.split('.');
-        if (stripFileName.length > 1) {
-            if (amsValidImageTypes.includes(stripFileName[1])) {
+        const stripFileName = extractExtensionFromFileName(fileName);
+        if (stripFileName) {
+            if (amsValidImageTypes.includes(stripFileName)) {
                 return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateImageType : DocumentTypes.UploadImageType;
             } else {
                 return apiOperation === AmsApiOperation.Create ? DocumentTypes.CreateDocumentType : DocumentTypes.UploadDocumentType;

--- a/src/API.ts
+++ b/src/API.ts
@@ -35,7 +35,7 @@ interface AMSHeaders {
     [HeadersName.AcceptEncoding]?: string;
 }
 
-const validImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'heic','heif','webp'];
+const validImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'heic', 'heif', 'webp'];
 
 const patchChatToken = (chatToken: OmnichannelChatToken) => {
     // Temporary

--- a/src/API.ts
+++ b/src/API.ts
@@ -35,7 +35,7 @@ interface AMSHeaders {
     [HeadersName.AcceptEncoding]?: string;
 }
 
-const validImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'bmp', 'tiff', 'jfif', 'webp'];
+const validImageTypes = ['jpeg', 'jpg', 'gif', 'png', 'heic','heif','webp'];
 
 const patchChatToken = (chatToken: OmnichannelChatToken) => {
     // Temporary

--- a/src/API.ts
+++ b/src/API.ts
@@ -94,12 +94,12 @@ const skypeTokenAuth = async (chatToken: OmnichannelChatToken): Promise<Response
     }
 }
 
-const extractExtensionFromFileName = (fileName : string) : string => {
-    if (fileName){
+const extractExtensionFromFileName = (fileName: string): string | undefined => {
+    if (fileName) {
         //this return the pure extension , or the whole name in case of not '.' in the string
-        return fileName.substring(fileName.lastIndexOf('.')+1);
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
     }
-    return fileName;
+    return undefined;
 }
 
 const defineTypeForOperation = (fileType: string, fileName: string, apiOperation: string) => {

--- a/src/FramedClient.ts
+++ b/src/FramedClient.ts
@@ -2,7 +2,7 @@ import AMSCreateObjectResponse from "./AMSCreateObjectResponse";
 import AMSFileInfo from "./AMSFileInfo";
 import AMSLogger from "./AMSLogger";
 import AMSViewStatusResponse from "./AMSViewStatusResponse";
-import {baseUrl, sdkVersion} from "./config";
+import { baseUrl, sdkVersion } from "./config";
 import FileMetadata from "./FileMetadata";
 import FramedClientConfig from "./FramedClientConfig";
 import GlobalConfiguration from "./GlobalConfiguration";
@@ -93,13 +93,14 @@ class FramedClient {
         })
     }
 
-    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null): Promise<void> {
+    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
         /* istanbul ignore next */
         this.debug && console.log(`[FramedClient][createObject]`);
         const data = {
             id,
             file,
-            chatToken: chatToken || this.chatToken
+            chatToken: chatToken || this.chatToken,
+            supportedImagesMimeTypes
         };
 
         await this.loadIframe();
@@ -109,13 +110,14 @@ class FramedClient {
         })
     }
 
-    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null): Promise<void> {
+    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
         /* istanbul ignore next */
         this.debug && console.log(`[FramedClient][uploadDocument]`);
         const data = {
             documentId,
             file,
-            chatToken: chatToken || this.chatToken
+            chatToken: chatToken || this.chatToken,
+            supportedImagesMimeTypes
         };
 
         await this.loadIframe();
@@ -125,10 +127,11 @@ class FramedClient {
         })
     }
 
-    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null): Promise<void> {
+    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
         const data = {
             fileMetadata,
-            chatToken: chatToken || this.chatToken
+            chatToken: chatToken || this.chatToken,
+            supportedImagesMimeTypes
         }
 
         await this.loadIframe();
@@ -138,11 +141,12 @@ class FramedClient {
         })
     }
 
-    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null): Promise<void> {
+    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
         const data = {
             fileMetadata,
             viewLocation,
-            chatToken: chatToken || this.chatToken
+            chatToken: chatToken || this.chatToken,
+            supportedImagesMimeTypes
         }
 
         await this.loadIframe();
@@ -208,7 +212,7 @@ class FramedClient {
         if (event.data.eventType === PostMessageEventType.Response) {
             /* istanbul ignore next */
             this.debug && console.log(`[FramedClient][Response]`);
-            const {data} = event;
+            const { data } = event;
 
             if (event.data.eventName === PostMessageEventName.SkypeTokenAuth) {
                 if (data.requestId in this.requestCallbacks) {
@@ -248,7 +252,7 @@ class FramedClient {
     }
 
     private async loadIframe(): Promise<void> {
-        return new Promise ((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const iframeElements = Array.from(document.getElementsByTagName('iframe'));
             const foundIframeElement = iframeElements.filter(iframeElement => iframeElement.id == this.iframeId);
 

--- a/src/FramedClient.ts
+++ b/src/FramedClient.ts
@@ -93,7 +93,7 @@ class FramedClient {
         })
     }
 
-    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
+    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<void> {
         /* istanbul ignore next */
         this.debug && console.log(`[FramedClient][createObject]`);
         const data = {
@@ -110,7 +110,7 @@ class FramedClient {
         })
     }
 
-    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
+    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<void> {
         /* istanbul ignore next */
         this.debug && console.log(`[FramedClient][uploadDocument]`);
         const data = {
@@ -127,7 +127,7 @@ class FramedClient {
         })
     }
 
-    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
+    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<void> {
         const data = {
             fileMetadata,
             chatToken: chatToken || this.chatToken,
@@ -141,7 +141,7 @@ class FramedClient {
         })
     }
 
-    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<void> {
+    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<void> {
         const data = {
             fileMetadata,
             viewLocation,

--- a/src/FramedlessClient.ts
+++ b/src/FramedlessClient.ts
@@ -67,7 +67,7 @@ class FramedlessClient {
         }
     }
 
-    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<AMSCreateObjectResponse> {
+    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<AMSCreateObjectResponse> {
         try {
             const response = await API.createObject(id, file, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
@@ -82,7 +82,7 @@ class FramedlessClient {
         }
     }
 
-    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<FileMetadata> {
+    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<FileMetadata> {
         try {
             const response = await API.uploadDocument(documentId, file, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
@@ -97,7 +97,7 @@ class FramedlessClient {
         }
     }
 
-    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<AMSViewStatusResponse> {
+    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<AMSViewStatusResponse> {
         try {
             const response = await API.getViewStatus(fileMetadata, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
@@ -112,7 +112,7 @@ class FramedlessClient {
         }
     }
 
-    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<Blob> {
+    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes: string[] = []): Promise<Blob> {
         try {
             const response = await API.getView(fileMetadata, viewLocation, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;

--- a/src/FramedlessClient.ts
+++ b/src/FramedlessClient.ts
@@ -48,7 +48,7 @@ class FramedlessClient {
             const response = await API.skypeTokenAuth(chatToken || this.chatToken);
             if (!response.ok) {
                 this.logger?.log(LogLevel.ERROR, PostMessageEventName.SkypeTokenAuth, {
-                    ChatId: chatToken? chatToken.chatId: this.chatToken?.chatId,
+                    ChatId: chatToken ? chatToken.chatId : this.chatToken?.chatId,
                     AMSClientVersion: sdkVersion,
                     ExceptionDetails: {
                         status: response.status
@@ -58,7 +58,7 @@ class FramedlessClient {
             return response;
         } catch (error) {
             this.logger?.log(LogLevel.ERROR, PostMessageEventName.SkypeTokenAuth, {
-                ChatId: chatToken? chatToken.chatId: this.chatToken.chatId,
+                ChatId: chatToken ? chatToken.chatId : this.chatToken.chatId,
                 AMSClientVersion: sdkVersion,
                 ExceptionDetails: error
             });
@@ -67,13 +67,13 @@ class FramedlessClient {
         }
     }
 
-    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null): Promise<AMSCreateObjectResponse> {
+    public async createObject(id: string, file: File, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<AMSCreateObjectResponse> {
         try {
-            const response = await API.createObject(id, file, chatToken || this.chatToken);
+            const response = await API.createObject(id, file, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
         } catch (error) {
             this.logger?.log(LogLevel.ERROR, PostMessageEventName.CreateObject, {
-                ChatId: chatToken? chatToken.chatId: this.chatToken.chatId,
+                ChatId: chatToken ? chatToken.chatId : this.chatToken.chatId,
                 AMSClientVersion: sdkVersion,
                 ExceptionDetails: error
             });
@@ -82,13 +82,13 @@ class FramedlessClient {
         }
     }
 
-    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null): Promise<FileMetadata> {
+    public async uploadDocument(documentId: string, file: File | AMSFileInfo, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<FileMetadata> {
         try {
-            const response = await API.uploadDocument(documentId, file, chatToken || this.chatToken);
+            const response = await API.uploadDocument(documentId, file, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
         } catch (error) {
             this.logger?.log(LogLevel.ERROR, PostMessageEventName.UploadDocument, {
-                ChatId: chatToken? chatToken.chatId: this.chatToken.chatId,
+                ChatId: chatToken ? chatToken.chatId : this.chatToken.chatId,
                 AMSClientVersion: sdkVersion,
                 ExceptionDetails: error
             });
@@ -97,13 +97,13 @@ class FramedlessClient {
         }
     }
 
-    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null): Promise<AMSViewStatusResponse> {
+    public async getViewStatus(fileMetadata: FileMetadata, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<AMSViewStatusResponse> {
         try {
-            const response = await API.getViewStatus(fileMetadata, chatToken || this.chatToken);
+            const response = await API.getViewStatus(fileMetadata, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
         } catch (error) {
             this.logger?.log(LogLevel.ERROR, PostMessageEventName.GetViewStatus, {
-                ChatId: chatToken? chatToken.chatId: this.chatToken.chatId,
+                ChatId: chatToken ? chatToken.chatId : this.chatToken.chatId,
                 AMSClientVersion: sdkVersion,
                 ExceptionDetails: error
             });
@@ -112,13 +112,13 @@ class FramedlessClient {
         }
     }
 
-    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null): Promise<Blob> {
+    public async getView(fileMetadata: FileMetadata, viewLocation: string, chatToken: OmnichannelChatToken | null = null, supportedImagesMimeTypes?: string[]): Promise<Blob> {
         try {
-            const response = await API.getView(fileMetadata, viewLocation, chatToken || this.chatToken);
+            const response = await API.getView(fileMetadata, viewLocation, chatToken || this.chatToken, supportedImagesMimeTypes);
             return response;
         } catch (error) {
             this.logger?.log(LogLevel.ERROR, PostMessageEventName.GetView, {
-                ChatId: chatToken? chatToken.chatId: this.chatToken.chatId,
+                ChatId: chatToken ? chatToken.chatId : this.chatToken.chatId,
                 AMSClientVersion: sdkVersion,
                 ExceptionDetails: error
             });


### PR DESCRIPTION
# Description

The current AMS client, doesnt evaluate over the file extension to classify the correct type of object to create/upload, this missing functionality plus the outdated list of supported file extensions by AMS, is causing that file like .tiff fail to be uploaded as attachment.

# Solution

Update component, based on list obtained from -> https://eng.ms/docs/experiences-devices/m365-core/ic3/messaging/async-media-transformation/troubleshooting/limitations/image-limitations

Add missing functionality , following next acceptance criteria :

1. if a file is an image  and its file extension is supported by AMS, then should be created and uploaded as image ( create : pish/image , upload : imgpsh)
2. if a file is an image and its file extension is NOT supported by AMS, the it should be created/uploaded as a document (create : sharing/file , upload:original)
3. any other file should be created as document (create : sharing/file , upload:original)

allowed format for images : 

1. JPEG
4. PNG
5. GIF
6. HEIC
5- WEBP

## TEST AND EVIDENCE

_*NOTE : UX changes were required, which are implemented in a separated PR*_

### TIFF file

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/981914/190876147-c485b777-48e4-4101-af57-be6682e1b6cf.png">

### BMP file 
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/981914/190876206-ce853e3c-6ee7-49a9-abd0-d0e577411ef0.png">


### PDF FILE
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/981914/190876228-80c1be5d-a904-42b6-9418-e50b97b82e43.png">

### JPEG FILE

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/981914/190876254-73234cbf-884b-4ff4-9558-255d6267dc09.png">





