### PR TITLE
Added error handling for createObject and uploadDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fix `FramedClient` not retrieving custom supported image MIME types
 
+### Added
+- Added error handling for createObject and uploadDocument
+
 ## [0.1.4] - 2023-02-09
 ### Added
 - Update `AMSLogData` to include `MimeType` & `FileExtension`

--- a/__tests__/API.spec.ts
+++ b/__tests__/API.spec.ts
@@ -43,12 +43,34 @@ describe('API', () => {
         };
 
         (global as any).fetch = jest.fn(() => Promise.resolve({
+            ok: true,
             json: () => Promise.resolve({})
         }));
 
         await API.createObject(id, file, token);
 
         expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('API.createObject() should throw error when response.ok is false', async () => {
+        const id = 'id';
+        const file =  new File([""], "filename", { type: 'text/html' });
+        const token = {
+            chatId: '',
+            token: ''
+        };
+
+        (global as any).fetch = jest.fn(() => Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve({})
+        }));
+
+        try {
+            await API.createObject(id, file, token);
+            fail('createObject should throw');
+        } catch (error) {
+            expect(error).not.toBe(undefined);
+        }
     });
 
     it('API.createObject() should throw an error if API does not succeed', async () => {
@@ -76,11 +98,29 @@ describe('API', () => {
             token: ''
         };
 
-        (global as any).fetch = jest.fn(() => Promise.resolve());
+        (global as any).fetch = jest.fn(() => Promise.resolve({ok: true}));
 
         await API.uploadDocument(documentId, file, token);
 
         expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('API.uploadDocument() should throw error when response.ok is false', async () => {
+        const documentId = 'documentId';
+        const file =  new File([""], "filename", { type: 'text/html' });
+        const token = {
+            chatId: '',
+            token: ''
+        };
+
+        (global as any).fetch = jest.fn(() => Promise.resolve({ok: false}));
+
+        try {
+            await API.uploadDocument(documentId, file, token);
+            fail('uploadDocument should throw');
+        } catch (error) {
+            expect(error).not.toBe(undefined);
+        }
     });
 
     it('API.uploadDocument() should throw an error if API does not succeed', async () => {

--- a/__tests__/API.spec.ts
+++ b/__tests__/API.spec.ts
@@ -98,7 +98,11 @@ describe('API', () => {
             token: ''
         };
 
-        (global as any).fetch = jest.fn(() => Promise.resolve({ok: true}));
+        (global as any).fetch = jest.fn(() => {
+            return new Promise((resolve, reject) => {
+                resolve({ok: true})
+            })
+        });
 
         await API.uploadDocument(documentId, file, token);
 

--- a/src/API.ts
+++ b/src/API.ts
@@ -139,6 +139,9 @@ const createObject = async (id: string, file: File, chatToken: OmnichannelChatTo
 
     try {
         const response = await fetch(url, request as any);  // eslint-disable-line @typescript-eslint/no-explicit-any
+        if (!response.ok) {
+            throw new Error("AMSCreateObjectFailed");
+        }
         const jsonResponse = await response.json();
         return jsonResponse; // returns document id
     } catch (error) {
@@ -165,7 +168,10 @@ const uploadDocument = async (documentId: string, file: File | AMSFileInfo, chat
         body: (file as any).data ? (file as AMSFileInfo).data : file as File  // eslint-disable-line @typescript-eslint/no-explicit-any
     };
     try {
-        await fetch(url, request as RequestInit);
+        const response = await fetch(url, request as RequestInit);
+        if (!response.ok) {
+            throw new Error("AMSUploadDocumentFailed");
+        }
         const fileMetadata = {
             name: file.name,
             size: file.size,

--- a/src/FramedClient.ts
+++ b/src/FramedClient.ts
@@ -13,6 +13,7 @@ import PostMessageEventName from "./PostMessageEventName";
 import PostMessageEventType from "./PostMessageEventType";
 import PostMessageRequestData from "./PostMessageRequestData";
 import { uuidv4 } from "./utils/uuid";
+import PostMessageEventStatus from "./PostMessageEventStatus";
 
 interface RequestCallback {
     resolve: CallableFunction,
@@ -223,14 +224,28 @@ class FramedClient {
                     delete this.requestCallbacks[data.requestId];
                 }
             } else if (event.data.eventName === PostMessageEventName.CreateObject) {
-                if (data.requestId in this.requestCallbacks) {
-                    this.requestCallbacks[data.requestId].resolve(data.response as AMSCreateObjectResponse);
-                    delete this.requestCallbacks[data.requestId];
+                if (data.eventStatus === PostMessageEventStatus.Success) {
+                    if (data.requestId in this.requestCallbacks) {
+                        this.requestCallbacks[data.requestId].resolve(data.response as AMSCreateObjectResponse);
+                        delete this.requestCallbacks[data.requestId];
+                    }
+                } else {
+                    if (data.requestId in this.requestCallbacks) {
+                        this.requestCallbacks[data.requestId].reject();
+                        delete this.requestCallbacks[data.requestId];
+                    }
                 }
             } else if (event.data.eventName === PostMessageEventName.UploadDocument) {
-                if (data.requestId in this.requestCallbacks) {
-                    this.requestCallbacks[data.requestId].resolve(data.response as FileMetadata);
-                    delete this.requestCallbacks[data.requestId];
+                if (data.eventStatus === PostMessageEventStatus.Success) {
+                    if (data.requestId in this.requestCallbacks) {
+                        this.requestCallbacks[data.requestId].resolve(data.response as FileMetadata);
+                        delete this.requestCallbacks[data.requestId];
+                    }
+                } else {
+                    if (data.requestId in this.requestCallbacks) {
+                        this.requestCallbacks[data.requestId].reject();
+                        delete this.requestCallbacks[data.requestId];
+                    }
                 }
             } else if (event.data.eventName === PostMessageEventName.GetViewStatus) {
                 if (data.requestId in this.requestCallbacks) {

--- a/src/IframeCommunicator.ts
+++ b/src/IframeCommunicator.ts
@@ -145,7 +145,14 @@ class IframeCommunicator {
 
                     this.postMessage(PostMessageEventType.Response, PostMessageEventName.CreateObject, postMessageData, PostMessageEventStatus.Success);
                 } catch (error) {
-                    this.postMessage(PostMessageEventType.Response, PostMessageEventName.CreateObject, {}, PostMessageEventStatus.Failure);
+                    const postMessageData = {
+                        requestId: data.requestId,
+                        eventType: PostMessageEventType.Response,
+                        eventName: data.eventName,
+                        eventStatus: PostMessageEventStatus.Failure
+                    };
+
+                    this.postMessage(PostMessageEventType.Response, PostMessageEventName.CreateObject, postMessageData, PostMessageEventStatus.Failure);
 
                     this.scenarioMarker.failScenario(PostMessageEventName.CreateObject, {
                         AMSClientRuntimeId: data.runtimeId,
@@ -185,7 +192,13 @@ class IframeCommunicator {
 
                     this.postMessage(PostMessageEventType.Response, PostMessageEventName.UploadDocument, postMessageData, PostMessageEventStatus.Success);
                 } catch (error) {
-                    this.postMessage(PostMessageEventType.Response, PostMessageEventName.UploadDocument, {}, PostMessageEventStatus.Failure);
+                    const postMessageData = {
+                        requestId: data.requestId,
+                        eventType: PostMessageEventType.Response,
+                        eventName: data.eventName,
+                        eventStatus: PostMessageEventStatus.Failure
+                    };
+                    this.postMessage(PostMessageEventType.Response, PostMessageEventName.UploadDocument, postMessageData, PostMessageEventStatus.Failure);
 
                     this.scenarioMarker.failScenario(PostMessageEventName.UploadDocument, {
                         AMSClientRuntimeId: data.runtimeId,


### PR DESCRIPTION
Currently when createObject or uploadDocument requests failed, it is still treated as a success, and a message is sent to ACS. This is causing data loss, as on C2 side the attachment is marked as successfully sent while in reality it is not