### PR TITLE
Restrict iFrame Target Origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `image/heic` & `image/webp` as part of `supportedImagesMimeTypes`
 
+### Changed
+- Update `FramedClient`'s `targetOrigin` to post cross-origin messages
+
 ## [0.1.6] - 2023-11-17
 ### Added
 - Added error handling for createObject and uploadDocument

--- a/src/FramedClient.ts
+++ b/src/FramedClient.ts
@@ -193,7 +193,7 @@ class FramedClient {
             eventType,
             eventName,
             ...data
-        }, '*');
+        }, baseUrl);
     }
 
     public async handleEvent(event: MessageEvent): Promise<void> {  // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
- Update `targetOrigin` to the `baseUrl` where the iFrame is hosted