### PR TITLE
Restrict IFrameCommunicator Target Origin to Document Referrer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Update `IframeCommunicator`'s `targetOrigin` to post cross-origin messages
+
 ## [0.1.7] - 2025-01-30
 ### Added
 - Add `image/heic` & `image/webp` as part of `supportedImagesMimeTypes`

--- a/src/IframeCommunicator.ts
+++ b/src/IframeCommunicator.ts
@@ -63,7 +63,7 @@ class IframeCommunicator {
             eventName,
             eventStatus,
             ...data
-        }, '*');
+        }, document.referrer);
     }
 
     public async handleEvent(event: MessageEvent<any>): Promise<void> {  // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
- Update targetOrigin to where the iFrame is linked to via `document.referrer` 