### PR TITLE
Remove 'document.referrer' Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Removal usage of `document.referrer` in `IframeCommunicator`
+
 ## [0.1.9] - 2025-05-22
 
 ### Added

--- a/src/IframeCommunicator.ts
+++ b/src/IframeCommunicator.ts
@@ -63,7 +63,7 @@ class IframeCommunicator {
             eventName,
             eventStatus,
             ...data
-        }, document.referrer);
+        }, '*');
     }
 
     public async handleEvent(event: MessageEvent<any>): Promise<void> {  // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
- `document.referrer` were causing issues, specially when web page does not have `<meta name="referrer" content="origin">` set or has other configurations