### PR TITLE
Automate official GitHub releases for v0.2.0

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,6 +17,8 @@ jobs:
   publish:
     if: github.repository == 'microsoft/omnichannel-amsclient'
     runs-on: ubuntu-latest
+    outputs:
+      release-tarball: ${{ steps.pack-release.outputs.filename }}
     steps:
       - name: Checking out for ${{ github.ref }}
         uses: actions/checkout@v4
@@ -37,6 +39,19 @@ jobs:
           echo "name=$(jq -r '.name' package.json)" >> "$GITHUB_OUTPUT"
           echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          EXPECTED_TAG="v${{ steps.read-package-json.outputs.version }}"
+          if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} does not match package version ${{ steps.read-package-json.outputs.version }}."
+            exit 1
+          fi
+          if [[ "${{ steps.read-package-json.outputs.version }}" == *-* ]]; then
+            echo "::error::Release tags cannot publish prerelease versions with the latest npm dist-tag."
+            exit 1
+          fi
+
       - name: Install packages
         run: npm install
 
@@ -52,5 +67,66 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Pack release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: pack-release
+        run: echo "filename=$(npm pack --json | jq -r '.[0].filename')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-tarball
+          path: ${{ steps.pack-release.outputs.filename }}
+          if-no-files-found: error
+
+      - name: Publish release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: npx npm@11.12.1 publish "${{ steps.pack-release.outputs.filename }}" --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: npx npm@11.12.1 publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+
+  github-release:
+    if: needs.publish.result == 'success' && github.repository == 'microsoft/omnichannel-amsclient' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out for ${{ github.ref }}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download release tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-tarball
+
+      - name: Extract CHANGELOG section for ${{ github.ref_name }}
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+            flag && /^## \[/ {flag=0}
+            flag {print}
+          ' docs/CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::warning::No CHANGELOG entry found for version $VERSION; falling back to auto-generated notes."
+            echo "fallback=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fallback=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: ${{ steps.changelog.outputs.fallback == 'false' && 'RELEASE_NOTES.md' || '' }}
+          generate_release_notes: ${{ steps.changelog.outputs.fallback == 'true' }}
+          files: ${{ needs.publish.outputs.release-tarball }}
+          fail_on_unmatched_files: true

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -114,7 +114,7 @@ jobs:
             flag && /^## \[/ {flag=0}
             flag {print}
           ' docs/CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
+          if ! grep -q '[^[:space:]]' RELEASE_NOTES.md; then
             echo "::warning::No CHANGELOG entry found for version $VERSION; falling back to auto-generated notes."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
           else

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Omnichannel AMSClient
 
 [![npm version](https://badge.fury.io/js/%40microsoft%2Fomnichannel-amsclient.svg)](https://badge.fury.io/js/%40microsoft%2Fomnichannel-amsclient)
-![Release CI](https://github.com/microsoft/omnichannel-amsclient/workflows/Release%20CI/badge.svg)
+[![npm Release](https://github.com/microsoft/omnichannel-amsclient/actions/workflows/npm-release.yml/badge.svg)](https://github.com/microsoft/omnichannel-amsclient/actions/workflows/npm-release.yml)
+[![CDN Release](https://github.com/microsoft/omnichannel-amsclient/actions/workflows/cdn-release.yml/badge.svg)](https://github.com/microsoft/omnichannel-amsclient/actions/workflows/cdn-release.yml)
 
 TypeScript client for Microsoft Azure Messaging Services (AMS) APIs. Handles file uploads and downloads in Omnichannel conversations. Compatible with Web (browser), Node.js, and React Native.
 
@@ -18,6 +19,7 @@ TypeScript client for Microsoft Azure Messaging Services (AMS) APIs. Handles fil
 - [File Download Flow](#file-download-flow)
 - [Telemetry](#telemetry)
 - [Development](#development)
+- [Releasing](#releasing)
 - [Contributing](#contributing)
 
 ## Installation
@@ -217,8 +219,14 @@ npm run lint               # ESLint
 ### CI
 
 - **Pull Request**: Build + test + lint (GitHub Actions, Node 22)
-- **Release**: Build CDN + npm package, upload to Azure Blob Storage, publish to npm registry
+- **npm Release**: Publish main builds and official releases to npm with provenance
+- **GitHub Release**: Create release notes and attach the published npm tarball for official `v*` tags
+- **CDN Release**: Upload versioned and `latest` bundles to Azure Blob Storage
 - **Azure Pipelines**: Component Governance scan
+
+## Releasing
+
+See [docs/RELEASING.md](docs/RELEASING.md) for development builds, official npm and GitHub releases, CDN publishing, and hotfixes.
 
 ## Contributing
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-12
+
 ### Changed
 
+- Added automatic GitHub Releases with changelog notes and the npm tarball for `v*` tags.
+- Documented that automatic `main` prereleases and official releases both use the npm `latest` dist-tag.
 - Refreshed Babel 7 and Lodash development-toolchain pins to clear dev-only audit findings; published `lib/` output is unchanged.
 - Scoped the development overrides to Jest and ts-jest and removed the unused `@babel/runtime-corejs3` override.
 - Standardized local, pull-request, and release builds on Node.js 22 and declared Node.js `>=22.12.0` as the supported runtime.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,63 +9,80 @@ This package uses **GitHub Actions OIDC trusted publishing** — no npm tokens o
 Every push to `main` automatically publishes a dev version to npm:
 
 ```
-0.1.14-main.abc1234
-       ^^^^^^^^^^^^
-       branch + short commit SHA (via version-from-git)
+0.2.0-main.abc1234
+      ^^^^^^^^^^^^
+      branch + short commit SHA (via version-from-git)
 ```
 
-- **npm tag**: `main` (not `latest`)
-- **Install**: `npm install @microsoft/omnichannel-amsclient@main`
+- **npm dist-tag**: `latest`
+- **Install**: Use the exact version from the workflow output, such as `npm install @microsoft/omnichannel-amsclient@0.2.0-main.abc1234`
 - **Triggered by**: Any merge/push to the `main` branch
+
+The workflow intentionally moves `latest` to each `main` prerelease. An unqualified install (`npm install @microsoft/omnichannel-amsclient`) can receive a prerelease. There is no `@main` dist-tag — the workflow does not create one.
 
 ### Release Versions (Manual — Tag Push)
 
-To publish a release version (e.g. `0.1.15`):
+To publish release version `0.2.0`:
 
-1. **Update the version** in `package.json`:
+1. **Make sure that `package.json` and `package-lock.json` contain `0.2.0`.**
+
+   These files already contain `0.2.0` for this release. If the files contain another version, run:
+
    ```bash
-   # Edit package.json version field to the new version
+   npm version 0.2.0 --no-git-tag-version
    ```
 
-2. **Update the changelog** in `docs/CHANGELOG.md`
+2. **Update `docs/CHANGELOG.md`.**
 
-3. **Commit and push** to main:
+   Move the release entries to `## [0.2.0] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above the release.
+
+3. **Open a pull request** with the version and changelog changes. Merge it after all required checks pass.
+
+4. **Update the local `main` branch**:
    ```bash
-   git add package.json docs/CHANGELOG.md
-   git commit -m "Bump version to 0.1.15"
-   git push
+   git checkout main
+   git pull --ff-only upstream main
    ```
 
-4. **Create and push a tag**:
+5. **Create and push the release tag**:
    ```bash
-   git tag v0.1.15
-   git push origin v0.1.15
+   git tag v0.2.0
+   git push upstream v0.2.0
    ```
 
-5. The `npm-release.yml` workflow will:
-   - Build the package (`npm run build:tsc`)
-   - Publish to npm with `--tag latest`
-   - Include provenance attestation (visible on npmjs.com)
+   The tag must equal `v` plus the version in `package.json`.
+
+6. **Wait for the `npm Release` workflow.**
+
+The workflow makes sure that the tag matches the package version. Then it builds and publishes the package with `--tag latest`.
+
+The workflow also adds a provenance attestation on npmjs.com. It creates GitHub Release `v0.2.0` with notes and the npm `.tgz` file.
 
 ### Verifying a Publish
 
 ```bash
-# Check latest release version
+# Read the version selected by latest
 npm view @microsoft/omnichannel-amsclient version
 
-# Check all dist-tags (latest + main)
+# Read all dist-tags
 npm view @microsoft/omnichannel-amsclient dist-tags
 
+# Check the official version
+npm view @microsoft/omnichannel-amsclient@0.2.0 version
+
 # Check a specific dev version
-npm view @microsoft/omnichannel-amsclient@main version
+npm view @microsoft/omnichannel-amsclient@0.2.0-main.abc1234 version
+
+# Check the GitHub Release and its asset
+gh release view v0.2.0 --repo microsoft/omnichannel-amsclient
 ```
 
 ### Tag Format
 
 | Tag pattern | What publishes | npm dist-tag |
 |-------------|---------------|--------------|
-| `v*` (e.g. `v0.1.15`) | Release version from `package.json` | `latest` |
-| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `main` |
+| `v*` (e.g. `v0.2.0`) | Release version from `package.json` | `latest` |
+| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `latest` |
 
 ### Hotfix Versions
 
@@ -95,6 +112,8 @@ For urgent fixes that need to ship against an older release (not `main`), use a 
    npm view @microsoft/omnichannel-amsclient@0.1.12-hotfix.<name>.1
    ```
 
+Do not create a `v*` tag for a hotfix prerelease. The workflow rejects prerelease tags to protect the `latest` dist-tag.
+
 #### Hotfix Version Naming Convention
 
 ```
@@ -109,6 +128,8 @@ Example: `0.1.12-hotfix.enau.1`
 
 ### Important Notes
 
-- **Burned versions**: If a publish fails, that version number is consumed by npm. You must bump to the next version.
+- **Published versions**: npm does not permit a second publish of the same version. Use a new version after npm accepts a bad publish.
 - **Trusted publisher**: Configured on npmjs.com to trust `microsoft/omnichannel-amsclient` → `npm-release.yml`. No npm tokens needed.
 - **Provenance**: All publishes include a signed provenance statement verifiable on npmjs.com.
+- **Release notes**: A matching changelog section supplies the GitHub Release notes. GitHub generates notes when the section is absent.
+- **Release asset**: Each GitHub Release contains the npm `.tgz` file from `npm pack`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,43 +20,76 @@ Every push to `main` automatically publishes a dev version to npm:
 
 The workflow intentionally moves `latest` to each `main` prerelease. An unqualified install (`npm install @microsoft/omnichannel-amsclient`) can receive a prerelease. There is no `@main` dist-tag — the workflow does not create one.
 
-### Release Versions (Manual — Tag Push)
+### Official Releases (Release PR and Tag)
 
-To publish release version `0.2.0`:
+Use an approved semantic version. In the examples below, replace `0.2.1` and `81` with the new version and pull-request number.
 
-1. **Make sure that `package.json` and `package-lock.json` contain `0.2.0`.**
+```bash
+VERSION=0.2.1
+PR_NUMBER=81
+```
 
-   These files already contain `0.2.0` for this release. If the files contain another version, run:
+1. **Create a release branch from current `upstream/main`.**
 
    ```bash
-   npm version 0.2.0 --no-git-tag-version
+   git fetch upstream
+   git checkout -b "release/v$VERSION" upstream/main
    ```
 
-2. **Update `docs/CHANGELOG.md`.**
+2. **Set the version in `package.json` and `package-lock.json`.**
 
-   Move the release entries to `## [0.2.0] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above the release.
-
-3. **Open a pull request** with the version and changelog changes. Merge it after all required checks pass.
-
-4. **Update the local `main` branch**:
    ```bash
-   git checkout main
-   git pull --ff-only upstream main
+   npm version "$VERSION" --no-git-tag-version
    ```
 
-5. **Create and push the release tag**:
+3. **Finalize `docs/CHANGELOG.md`.**
+
+   Move all release entries below `## [$VERSION] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above that heading.
+
+4. **Open a pull request.**
+
+   Include `package.json`, `package-lock.json`, and `docs/CHANGELOG.md`. Merge the pull request only after all required checks pass.
+
+   The merge to `main` publishes a `VERSION-main.SHA` prerelease with the npm `latest` dist-tag. This publish is expected.
+
+5. **Get the pull-request merge commit.**
+
    ```bash
-   git tag v0.2.0
-   git push upstream v0.2.0
+   MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo microsoft/omnichannel-amsclient --json mergeCommit --jq '.mergeCommit.oid')
+   test -n "$MERGE_SHA"
    ```
 
-   The tag must equal `v` plus the version in `package.json`.
+6. **Create an annotated tag on that merge commit.**
 
-6. **Wait for the `npm Release` workflow.**
+   ```bash
+   git fetch upstream --tags
+   git tag -a "v$VERSION" "$MERGE_SHA" -m "Release v$VERSION"
+   git push upstream "v$VERSION"
+   ```
 
-The workflow makes sure that the tag matches the package version. Then it builds and publishes the package with `--tag latest`.
+   The tag must equal `v` plus the version in `package.json`. The workflow rejects mismatched tags and prerelease tags.
 
-The workflow also adds a provenance attestation on npmjs.com. It creates GitHub Release `v0.2.0` with notes and the npm `.tgz` file.
+7. **Wait for the tag workflows.**
+
+Do not use **Run workflow** for an official release. The pushed tag starts the npm and CDN workflows.
+
+The npm workflow publishes the package with `--tag latest`. Then it creates GitHub Release `v$VERSION` with notes and the published npm tarball.
+
+### GitHub Release Notes
+
+The workflow removes `v` from the tag. For example, it converts `v0.2.1` to `0.2.1`.
+
+It finds `## [0.2.1]` in `docs/CHANGELOG.md`. It copies that section until the next `## [` version heading.
+
+The copied text becomes the GitHub Release body. If the matching section is empty or absent, GitHub generates notes from merged pull requests.
+
+The workflow packs the package once. It publishes that `.tgz` file to npm and attaches the same file to the GitHub Release.
+
+### CDN Release
+
+The `CDN Release` workflow also starts from the `v*` tag. It uploads the versioned bundle and updates the Production `latest` bundle.
+
+Before tag creation, make sure that the Production environment and Azure Storage secrets are available.
 
 ### Verifying a Publish
 
@@ -68,20 +101,23 @@ npm view @microsoft/omnichannel-amsclient version
 npm view @microsoft/omnichannel-amsclient dist-tags
 
 # Check the official version
-npm view @microsoft/omnichannel-amsclient@0.2.0 version
+npm view "@microsoft/omnichannel-amsclient@$VERSION" version
 
 # Check a specific dev version
 npm view @microsoft/omnichannel-amsclient@0.2.0-main.abc1234 version
 
 # Check the GitHub Release and its asset
-gh release view v0.2.0 --repo microsoft/omnichannel-amsclient
+gh release view "v$VERSION" --repo microsoft/omnichannel-amsclient
+
+# Check the versioned CDN bundle
+curl -I "https://comms.omnichannelengagementhub.com/ams/$VERSION/iframe.html"
 ```
 
 ### Tag Format
 
 | Tag pattern | What publishes | npm dist-tag |
 |-------------|---------------|--------------|
-| `v*` (e.g. `v0.2.0`) | Release version from `package.json` | `latest` |
+| `v*` (e.g. `v0.2.1`) | Release version from `package.json` | `latest` |
 | Push to `main` | Dev version `X.Y.Z-main.<sha>` | `latest` |
 
 ### Hotfix Versions


### PR DESCRIPTION
## Summary
- create a GitHub Release for each official `v*` tag after npm publishing succeeds
- publish and attach the same packed npm tarball
- validate that the tag matches `package.json` and reject prerelease tags
- document that automatic `main` prereleases intentionally use the npm `latest` dist-tag
- finalize the changelog for `0.2.0`

## Release flow
After this PR merges, create and push `v0.2.0` from the merged `main` commit. The npm workflow will publish `@microsoft/omnichannel-amsclient@0.2.0`, then create GitHub Release `v0.2.0` with changelog notes and the `.tgz` asset. The existing CDN workflow will also run for the tag.

## Validation
- `npm run build:tsc`
- `npm test` — 10 suites, 50 tests passed
- `npm run lint` — 0 errors, 3 existing warnings
- `npm pack --dry-run`
- workflow YAML and changelog extraction checks